### PR TITLE
stateをリセットするサンプル

### DIFF
--- a/pages/shindan/index.tsx
+++ b/pages/shindan/index.tsx
@@ -10,7 +10,7 @@ const Shindan: NextPage = () => {
     const dispatch = useAppDispatch();
     React.useEffect(() => {
       dispatch(reset());
-    });
+    }, []);
 
 	return (
 		<DefaultLayout>

--- a/pages/shindan/index.tsx
+++ b/pages/shindan/index.tsx
@@ -1,9 +1,17 @@
+import React from "react";
 import {NextPage} from "next";
 import {DefaultLayout} from "../../layout/DefaultLayout";
 import {Button, Divider, Grid, Paper, Typography} from "@mui/material";
 import Link from "next/link";
+import {useAppDispatch} from "../../redux/hook";
+import {reset} from "../../redux/reducer/question";
 
 const Shindan: NextPage = () => {
+    const dispatch = useAppDispatch();
+    React.useEffect(() => {
+      dispatch(reset());
+    });
+
 	return (
 		<DefaultLayout>
 			<Typography variant={"h5"}>

--- a/pages/shindan/index.tsx
+++ b/pages/shindan/index.tsx
@@ -4,12 +4,12 @@ import {DefaultLayout} from "../../layout/DefaultLayout";
 import {Button, Divider, Grid, Paper, Typography} from "@mui/material";
 import Link from "next/link";
 import {useAppDispatch} from "../../redux/hook";
-import {reset} from "../../redux/reducer/question";
+import {resetAnswers} from "../../redux/reducer/question";
 
 const Shindan: NextPage = () => {
     const dispatch = useAppDispatch();
     React.useEffect(() => {
-      dispatch(reset());
+      dispatch(resetAnswers());
     }, []);
 
 	return (

--- a/redux/reducer/question.ts
+++ b/redux/reducer/question.ts
@@ -38,8 +38,11 @@ export const questionSlice = createSlice({   //createSlice=変数、初期値や
 					? 2
 						: 3;
 	},
-	}
+    reset: (state) => {
+      return initialState;
+    },
+  }
 })
 
-export const {answerQuestion} = questionSlice.actions;
+export const {answerQuestion, reset} = questionSlice.actions;
 export default questionSlice.reducer;

--- a/redux/reducer/question.ts
+++ b/redux/reducer/question.ts
@@ -38,11 +38,11 @@ export const questionSlice = createSlice({   //createSlice=変数、初期値や
 					? 2
 						: 3;
 	},
-    reset: (state) => {
+    resetAnswers: (state) => {
       return initialState;
     },
   }
 })
 
-export const {answerQuestion, reset} = questionSlice.actions;
+export const {answerQuestion, resetAnswers} = questionSlice.actions;
 export default questionSlice.reducer;


### PR DESCRIPTION

- stateは基本的にreducerごとにリセットしたいので、reducerのアクションとしてresetAnswersを定義
  -   処理内容はinitialStateを返すだけ
- useEffectでresetを実行すればページを開いた時にリセットできる
  - 第2引数を空配列にしないと再レンダリングされる度にリセットされてしまうので注意